### PR TITLE
use a shallow clone when fetching the target repo

### DIFF
--- a/.github/workflows/pull-map-and-push-repo.yml
+++ b/.github/workflows/pull-map-and-push-repo.yml
@@ -76,7 +76,7 @@ jobs:
       - name: pull-external
         run: |
           mkdir temp-pull && cd temp-pull &&
-          git clone ${{inputs.target_source_repo}} && ls -r
+          git clone ${{inputs.target_source_repo}} --depth 1 && ls -r
       - name: copy-target-to-new-location
         run: |
           sources_array=(${{inputs.copy_mapping_sources}})


### PR DESCRIPTION
Running a shallow clone can reduce the time it takes to clone the project since it only pulls the latest commit from the main branch.

Side by side comparison:
![shallow_clone](https://user-images.githubusercontent.com/16766726/234592537-938630a3-96af-4f94-b73d-1167feba7fc6.png)
